### PR TITLE
copilot/upgrade-spring-boot-java-25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ IMPORTANTE CONSIDERAR:
         <spring-boot.version>4.0.0</spring-boot.version>
         <spring-cloud.version>2025.1.0</spring-cloud.version>
         <!--        JUnit 5.x-->
-        <junit.jupiter.version>5.11.3</junit.jupiter.version>
+        <junit.jupiter.version>6.0.1</junit.jupiter.version>
         <junit.jupiter.core.version>5.9.3</junit.jupiter.core.version>
         <!--        Mockito-->
         <mockserver.junit.jupiter.version>5.15.0</mockserver.junit.jupiter.version>
@@ -91,7 +91,7 @@ IMPORTANTE CONSIDERAR:
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.6.0</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
@@ -199,7 +199,7 @@ IMPORTANTE CONSIDERAR:
                     <dependency>
                         <groupId>org.ow2.asm</groupId>
                         <artifactId>asm</artifactId>
-                        <version>9.7.1</version>
+                        <version>9.8</version>
                     </dependency>
                 </dependencies>
                 <version>${maven.surefire.version}</version>
@@ -207,17 +207,17 @@ IMPORTANTE CONSIDERAR:
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.16.2</version>
+                <version>2.17.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <configuration>
                     <rules>
                         <dependencyConvergence/>


### PR DESCRIPTION
This pull request updates several dependencies and plugins in the `pom.xml` file to newer versions, primarily to keep the project up-to-date with the latest features, bug fixes, and security patches. The changes focus on upgrading testing, documentation, and build-related components.

Dependency upgrades:

* Updated `junit.jupiter.version` to `6.0.1` for newer JUnit 5 support.
* Upgraded `springdoc-openapi-starter-webmvc-ui` dependency to version `3.0.0`.

Build and plugin upgrades:

* Updated `org.ow2.asm:asm` to version `9.8`.
* Upgraded several Maven plugins to their latest versions:
  - `build-helper-maven-plugin` to `3.6.0`
  - `versions-maven-plugin` to `2.17.1`
  - `maven-enforcer-plugin` to `3.5.0`